### PR TITLE
Fixed System.IO.PathTooLongException while searching for Unity on Windows

### DIFF
--- a/src/Cake.Unity/SeekersOfEditors/OSXSeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/OSXSeekerOfEditors.cs
@@ -20,7 +20,7 @@ namespace Cake.Unity.SeekersOfEditors
             this.fileSystem = fileSystem;
         }
 
-        protected override string SearchPattern => "/Applications/**/Unity*.app/Contents/MacOS/Unity";
+        protected override string[] SearchPatterns => new[] {"/Applications/**/Unity*.app/Contents/MacOS/Unity"};
 
         protected override UnityVersion DetermineVersion(FilePath editorPath)
         {

--- a/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
@@ -35,7 +35,7 @@ namespace Cake.Unity.SeekersOfEditors
         public IReadOnlyCollection<UnityEditorDescriptor> Seek()
         {
             log.Debug("Searching for available Unity Editors...");
-            log.Debug("Search patterns: {0}", SearchPatterns);
+            log.Debug("Search patterns: [{0}]", string.Join(", ", SearchPatterns));
             var candidates = GetCandidates(SearchPatterns);
 
             log.Debug("Found {0} candidates.", candidates.Count);
@@ -50,11 +50,11 @@ namespace Cake.Unity.SeekersOfEditors
             return editors.ToList();
         }
 
-        private List<FilePath> GetCandidates(string[] searchPatterns) =>
-            searchPatterns.SelectMany(globber.GetFiles).ToList();
-
         protected abstract string[] SearchPatterns { get; }
 
         protected abstract UnityVersion DetermineVersion(FilePath editorPath);
+
+        private List<FilePath> GetCandidates(string[] searchPatterns) =>
+            searchPatterns.SelectMany(globber.GetFiles).ToList();
     }
 }

--- a/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
@@ -34,11 +34,9 @@ namespace Cake.Unity.SeekersOfEditors
 
         public IReadOnlyCollection<UnityEditorDescriptor> Seek()
         {
-            var searchPattern = SearchPattern;
-
             log.Debug("Searching for available Unity Editors...");
-            log.Debug("Search pattern: {0}", searchPattern);
-            var candidates = globber.GetFiles(searchPattern).ToList();
+            log.Debug("Search patterns: {0}", SearchPatterns);
+            var candidates = GetCandidates(SearchPatterns);
 
             log.Debug("Found {0} candidates.", candidates.Count);
             log.Debug(string.Empty);
@@ -52,7 +50,10 @@ namespace Cake.Unity.SeekersOfEditors
             return editors.ToList();
         }
 
-        protected abstract string SearchPattern { get; }
+        private List<FilePath> GetCandidates(string[] searchPatterns) =>
+            searchPatterns.SelectMany(globber.GetFiles).ToList();
+
+        protected abstract string[] SearchPatterns { get; }
 
         protected abstract UnityVersion DetermineVersion(FilePath editorPath);
     }

--- a/src/Cake.Unity/SeekersOfEditors/WindowsSeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/WindowsSeekerOfEditors.cs
@@ -10,11 +10,16 @@ namespace Cake.Unity.SeekersOfEditors
     internal class WindowsSeekerOfEditors : SeekerOfEditors
     {
         public WindowsSeekerOfEditors(ICakeEnvironment environment, IGlobber globber, ICakeLog log)
-            : base(environment, globber, log)
-        { }
+            : base(environment, globber, log) { }
 
         private string ProgramFiles => environment.GetSpecialPath(SpecialPath.ProgramFiles).FullPath;
-        protected override string SearchPattern => $"{ProgramFiles}/*Unity*/**/Editor/Unity.exe";
+
+        protected override string[] SearchPatterns => new []
+        {
+            $"{ProgramFiles}/*Unity*/*/Editor/Unity.exe",
+            $"{ProgramFiles}/*Unity*/*/*/Editor/Unity.exe",
+            $"{ProgramFiles}/*Unity*/*/*/*/Editor/Unity.exe"
+        };
 
         protected override UnityVersion DetermineVersion(FilePath editorPath)
         {


### PR DESCRIPTION
Added multiple search patterns support for SeekerOfEditors.