### PR TITLE
added linux support to the editor seeker

### DIFF
--- a/src/Cake.Unity/SeekersOfEditors/LinuxSeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/LinuxSeekerOfEditors.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Unity.Version;
+using System.Text.RegularExpressions;
+
+[assembly: InternalsVisibleTo("Cake.Unity.FSharp.Tests")]
+namespace Cake.Unity.SeekersOfEditors
+{
+    internal class LinuxSeekerOfEditors : SeekerOfEditors
+    {
+        private readonly IFileSystem fileSystem;
+        private readonly Regex VersionRegex = new Regex("(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<branch>\\w)(?<build>\\d+)");
+
+        public LinuxSeekerOfEditors(ICakeEnvironment environment, IGlobber globber, ICakeLog log, IFileSystem fileSystem)
+            : base(environment, globber, log)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        protected override string[] SearchPatterns => new[] {
+            "/home/*/Unity/Hub/Editor/*/Editor/Unity"
+            };
+
+        protected override UnityVersion DetermineVersion(FilePath editorPath)
+        {
+            log.Debug($"Determining version of Unity Editor at path {editorPath}...");
+
+            var versionMatch = VersionRegex.Match(editorPath.FullPath);
+
+            if(!versionMatch.Success)
+            {
+                log.Debug($"Can't find UnityVersion for {editorPath}");
+                return null;
+            }
+
+            var major = int.Parse(versionMatch.Groups["major"].Value);
+            var minor = int.Parse(versionMatch.Groups["minor"].Value);
+            var patch = int.Parse(versionMatch.Groups["patch"].Value);
+            var branch = char.Parse(versionMatch.Groups["branch"].Value);
+            var build = int.Parse(versionMatch.Groups["build"].Value);
+
+            var unityVersion = new UnityVersion(major, minor, patch, branch, build);
+
+            log.Debug($"Result Unity Editor version (full): {unityVersion}");
+            return unityVersion;
+        }
+    }
+}

--- a/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
+++ b/src/Cake.Unity/SeekersOfEditors/SeekerOfEditors.cs
@@ -22,7 +22,10 @@ namespace Cake.Unity.SeekersOfEditors
             if (environment.Platform.Family == PlatformFamily.OSX)
                 return new OSXSeekerOfEditors(environment, globber, log, fileSystem);
 
-            throw new NotSupportedException("Cannot locate Unity Editors. Only Windows and OSX platform is supported.");
+            if (environment.Platform.Family == PlatformFamily.Linux)
+                return new LinuxSeekerOfEditors(environment, globber, log, fileSystem);
+
+            throw new NotSupportedException("Cannot locate Unity Editors. Only Windows, OSX and Linux is supported.");
         }
 
         protected SeekerOfEditors(ICakeEnvironment environment, IGlobber globber, ICakeLog log)


### PR DESCRIPTION
This PR adds Linux support to seek editors installed into the default location `/home/<user>/Unity/Editor/<version>/Editor/Unity`

If you have more default paths than I'm happy to add them