### PR TITLE
Add 'releaseCodeOptimization' argument option

### DIFF
--- a/src/Cake.Unity.FSharp.Tests/UnityEditorArgumentsTests.fs
+++ b/src/Cake.Unity.FSharp.Tests/UnityEditorArgumentsTests.fs
@@ -21,9 +21,17 @@ let setExecuteMethod value (arguments : UnityEditorArguments) =
     arguments.ExecuteMethod <- value
     arguments
 
+let setReleaseCodeOptimization value (arguments : UnityEditorArguments) =
+    arguments.ReleaseCodeOptimization <- value
+    arguments
+
 [<Test>]
 let ``CLI arguments with enabled BatchMode should contain "-batchmode"`` () =
     () |> UnityEditorArguments |> setBatchMode true |> commandLineArguments |> should haveSubstring "-batchmode"
+
+[<Test>]
+let ``CLI arguments with release code optimization should contain "-releaseCodeOptimization"`` () =
+    () |> UnityEditorArguments |> setReleaseCodeOptimization true |> commandLineArguments |> should haveSubstring "-releaseCodeOptimization"
 
 [<Test>]
 let ``CLI arguments with custom argument "age" of value 18 should contain "--age=18"`` () =

--- a/src/Cake.Unity/UnityEditorArguments.cs
+++ b/src/Cake.Unity/UnityEditorArguments.cs
@@ -233,6 +233,11 @@ namespace Cake.Unity
         public bool AcceptAPIUpdate { get; set; }
 
         /// <summary>
+        /// Enables release code optimization mode, overriding the current default code optimization mode for the session.
+        /// </summary>
+        public bool ReleaseCodeOptimization { get; set; }
+
+        /// <summary>
         /// <para>Custom arguments which can further be processed in Unity Editor script by calling System.Environment.GetCommandLineArgs method. </para>
         /// <para>They are supplied among other arguments in format "--key=value". </para>
         /// <para>Expected to be used in conjunction with ExecuteMethod argument. </para>
@@ -473,6 +478,9 @@ namespace Cake.Unity
 
             if (AcceptAPIUpdate)
                 builder.Append("-accept-apiupdate");
+
+            if (ReleaseCodeOptimization)
+                builder.Append("-releaseCodeOptimization");
 
             foreach (var customArgument in customArguments)
                 builder.AppendQuoted($"--{customArgument.Key}={customArgument.Value}");


### PR DESCRIPTION
This PR adds the Unity editor command line option _releaseCodeOptimization_ which disables debugging support in favor of optimized C# code. This option makes sense on dedicated build machines where debugging is usually not performed and the editor is used for long-running tasks such as running tests or performing AssetDatabase operations. In these situations it can be a speed improvement to use release-mode code.