### PR TITLE
Add custom build target support and add build targets for GDK and PS5

### DIFF
--- a/src/Cake.Unity.FSharp.Tests/UnityEditorArgumentsTests.fs
+++ b/src/Cake.Unity.FSharp.Tests/UnityEditorArgumentsTests.fs
@@ -1,5 +1,7 @@
 ﻿module Cake.Unity.Tests.UnityEditorArgumentsTests
 
+open System
+open Cake.Unity.Arguments
 open FSharp.Interop.Dynamic
 open FsUnit.TopLevelOperators
 open NUnit.Framework
@@ -20,6 +22,11 @@ let setBatchMode value (arguments : UnityEditorArguments) =
 let setExecuteMethod value (arguments : UnityEditorArguments) =
     arguments.ExecuteMethod <- value
     arguments
+
+let setCustomBuildTarget value (arguments : UnityEditorArguments) =
+    arguments.CustomBuildTarget <- value
+    arguments
+
 
 [<Test>]
 let ``CLI arguments with enabled BatchMode should contain "-batchmode"`` () =
@@ -48,3 +55,8 @@ let ``default BatchMode value should be true`` () =
 [<Test>]
 let ``default Quit value should be true`` () =
     UnityEditorArguments().Quit |> should equal true
+
+[<Test>]
+let ``CLI arguments with Custom argument "CustomBuildTarget" of value "PS5" should contain "-buildTarget PS5"`` () =
+    () |> UnityEditorArguments |> setCustomBuildTarget "PS5" |> commandLineArguments |> should haveSubstring "-buildTarget PS5"
+

--- a/src/Cake.Unity/Arguments/BuildTarget.cs
+++ b/src/Cake.Unity/Arguments/BuildTarget.cs
@@ -23,5 +23,10 @@
         N3DS,
         tvOS,
         PSM,
+
+        GameCoreXboxSeries,
+        GameCoreXboxOne,
+        GameCoreScarlett,
+        PS5,
     }
 }

--- a/src/Cake.Unity/UnityEditorArguments.cs
+++ b/src/Cake.Unity/UnityEditorArguments.cs
@@ -337,12 +337,12 @@ namespace Cake.Unity
             {
                 builder
                     .Append("-buildTarget")
-                    .AppendQuoted(CustomBuildTarget);
+                    .Append(CustomBuildTarget);
             }
 
             if (CustomBuildTarget != null && BuildTarget.HasValue)
             {
-                throw new Exception("Providing both BuildTarget and CustomBuildTarget is not supported.");
+                throw new ArgumentException("Providing both BuildTarget and CustomBuildTarget is not supported.");
             }
 
             if (BuildWindowsPlayer != null)

--- a/src/Cake.Unity/UnityEditorArguments.cs
+++ b/src/Cake.Unity/UnityEditorArguments.cs
@@ -61,6 +61,11 @@ namespace Cake.Unity
         public BuildTarget? BuildTarget { get; set; }
 
         /// <summary>
+        /// Allows the selection of an active build target before loading a project (with string).
+        /// </summary>
+        public string CustomBuildTarget { get; set; }
+
+        /// <summary>
         /// Build a 32-bit standalone Windows player (for example, -buildWindowsPlayer path/to/your/build.exe).
         /// </summary>
         public FilePath BuildWindowsPlayer { get; set; }
@@ -327,6 +332,18 @@ namespace Cake.Unity
                 builder
                     .Append("-buildTarget")
                     .Append(BuildTarget.Value.ToString());
+
+            if (CustomBuildTarget != null)
+            {
+                builder
+                    .Append("-buildTarget")
+                    .AppendQuoted(CustomBuildTarget);
+            }
+
+            if (CustomBuildTarget != null && BuildTarget.HasValue)
+            {
+                throw new Exception("Providing both BuildTarget and CustomBuildTarget is not supported.");
+            }
 
             if (BuildWindowsPlayer != null)
                 builder


### PR DESCRIPTION
- Add new UnityEditorArgument property CustomBuildTarget, which can be used instead of the BuildTarget enum field.

 - Add GDK and PS5 build targets